### PR TITLE
Elixir 1.5.2 facelift.

### DIFF
--- a/lib/teamcity_exunit_formatter.ex
+++ b/lib/teamcity_exunit_formatter.ex
@@ -1,7 +1,10 @@
 defmodule TeamCityExUnitFormatter do
   @moduledoc false
 
-  use GenEvent
+  use GenServer
+
+  import ExUnit.Formatter,
+    only: [format_test_failure: 5]
 
   def formatter(_color, msg), do: msg
 
@@ -18,53 +21,50 @@ defmodule TeamCityExUnitFormatter do
     {:ok, config}
   end
 
-  def handle_event({:case_started, %ExUnit.TestCase{name: name}}, config) do
+  def handle_cast({:case_started, %ExUnit.TestCase{name: name}}, config) do
     IO.puts format :test_suite_started, name: name, flowId: name
-    {:ok, config}
+    {:noreply, config}
   end
 
-  def handle_event({:case_finished, %ExUnit.TestCase{name: name}}, config) do
+  def handle_cast({:case_finished, %ExUnit.TestCase{name: name}}, config) do
     IO.puts format :test_suite_finished, name: name, flowId: name
-    {:ok, config}
+    {:noreply, config}
   end
 
-  def handle_event({:test_started, %ExUnit.Test{name: name, case: the_case}}, config) do
+  def handle_cast({:test_started, %ExUnit.Test{name: name, case: the_case}}, config) do
     IO.puts format :test_started, name: "#{the_case}.#{name}", flowId: the_case
-    {:ok, config}
+    {:noreply, config}
   end
 
-  def handle_event({:test_finished, %ExUnit.Test{name: name, case: the_case, time: time, state: {:failed, {_, reason, _} = failed}} = test}, config) do
-    formatted = ExUnit.Formatter.format_test_failure(test, failed, config.failures_counter + 1, config.width, &formatter/2)
+  def handle_cast({:test_finished, %ExUnit.Test{name: name, case: the_case, time: time, state: {:failed, {_, reason, _} = failed}} = test}, config) do
+    formatted = format_test_failure(test, failed, config.failures_counter + 1, config.width, &formatter/2)
     IO.puts format :test_failed, name: "#{the_case}.#{name}", message: inspect(reason), details: formatted, flowId: the_case
     IO.puts format :test_finished, name: "#{the_case}.#{name}", duration: div(time, 1000), flowId: the_case
-    {:ok, %{config | tests_counter: config.tests_counter + 1,
-                     failures_counter: config.failures_counter + 1}}
+    {:noreply, config}
   end
 
-  def handle_event({:test_finished, %ExUnit.Test{name: name, case: the_case, time: time, state: {:failed, failed}} = test}, config) when is_list(failed) do
-    formatted = ExUnit.Formatter.format_test_failure(test, failed, config.failures_counter + 1, config.width, &formatter/2)
+  def handle_cast({:test_finished, %ExUnit.Test{name: name, case: the_case, time: time, state: {:failed, failed}} = test}, config) when is_list(failed) do
+    formatted = format_test_failure(test, failed, config.failures_counter + 1, config.width, &formatter/2)
 
     message = Enum.map_join(failed, "", fn {_kind, reason, _stack} -> inspect(reason) end)
     IO.puts format :test_failed, name: "#{the_case}.#{name}", message: message, details: formatted, flowId: the_case
     IO.puts format :test_finished, name: "#{the_case}.#{name}", duration: div(time, 1000), flowId: the_case
-    {:ok, %{config | tests_counter: config.tests_counter + 1,
-                     failures_counter: config.failures_counter + 1}}
+    {:noreply, config}
   end
 
-  def handle_event({:test_finished, %ExUnit.Test{name: name, case: the_case, state: {:skip, _}}}, config) do
+  def handle_cast({:test_finished, %ExUnit.Test{name: name, case: the_case, state: {:skip, _}}}, config) do
     IO.puts format :test_ignored, name: "#{the_case}.#{name}", flowId: the_case
     IO.puts format :test_finished, name: "#{the_case}.#{name}", flowId: the_case
-    {:ok, %{config | tests_counter: config.tests_counter + 1,
-                     skipped_counter: config.skipped_counter + 1}}
+    {:noreply, config}
   end
 
-  def handle_event({:test_finished, %ExUnit.Test{name: name, case: the_case, time: time}}, config) do
+  def handle_cast({:test_finished, %ExUnit.Test{name: name, case: the_case, time: time}}, config) do
     IO.puts format :test_finished, name: "#{the_case}.#{name}", duration: div(time, 1000), flowId: the_case
-    {:ok, config}
+    {:noreply, config}
   end
 
-  def handle_event(_, config) do
-    {:ok, config}
+  def handle_cast(_, config) do
+    {:noreply, config}
   end
 
   defp format(type, attributes) do


### PR DESCRIPTION
- The formatter is now a GenServer.
- Testsuite does not blow up on flowId being present.